### PR TITLE
Add edit/delete trade actions to UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.db

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,28 @@
+# TradeLedger Project Progress
+
+_Last updated: 2025-06-05_
+
+## ✅ Completed
+- Designed trade data model (SQLite schema in `db.py`).
+- Implemented basic CRUD functions: add, view, edit, delete trades.
+- Created Streamlit app with manual trade entry form and trade table display.
+- Basic P&L aggregation and dashboard charts (daily/weekly/monthly).
+
+## 🚧 In Progress / Next Steps
+- Add edit and delete functionality to the UI (Streamlit table actions).
+- Add basic data validation for trade entries (required fields, positive numbers).
+- Add filtering/searching by ticker, date, or tags in the trade table.
+- CSV import/export (start with IBKR format).
+- More analytics: equity curve, drawdown, win rate, best/worst trades, etc.
+- Risk management logic and warnings.
+- Tagging, notes, and journaling enhancements.
+- Modular dashboard widgets.
+
+## 📝 Notes
+- Code is modular and uses type hints/docstrings.
+- All code is self-hosted, no cloud dependencies.
+- See `readme.md` for full feature list and roadmap.
+
+---
+
+Feel free to update this file as progress is made or priorities change.

--- a/readme.md
+++ b/readme.md
@@ -42,18 +42,18 @@ A private, customizable trade journal and analytics dashboard for Interactive Br
 
 2. **Install requirements:**
     ```bash
-    pip install -r requirements.txt
+    pip install -r tradeledger/requirements.txt
     ```
 
-3. **(Optional) Set up IBKR API access:**  
+3. **(Optional) Set up IBKR API access:**
     Follow the [ib_insync guide](https://github.com/erdewit/ib_insync) or use CSV exports from IBKR.
 
 4. **Run the app:**
     ```bash
-    streamlit run app.py
+    streamlit run tradeledger/app.py
     ```
 
-5. **Start journaling!**  
+5. **Start journaling!**
     Import or manually enter your trades and explore your dashboard.
 
 ---
@@ -86,4 +86,3 @@ MIT License. See [LICENSE](LICENSE) for details.
 Open an issue or start a discussion!
 
 ---
-

--- a/tradeledger/__init__.py
+++ b/tradeledger/__init__.py
@@ -1,0 +1,1 @@
+"""TradeLedger main package."""

--- a/tradeledger/app.py
+++ b/tradeledger/app.py
@@ -39,12 +39,77 @@ if page == 'Trade Log':
                 tags=tags,
             )
             st.success('Trade added')
+            st.experimental_rerun()
+
+    trades_df = db.fetch_trades()
+
+    # Handle edit form
+    if st.session_state.get('edit_id') is not None:
+        trade_to_edit = trades_df[trades_df['id'] == st.session_state['edit_id']]
+        if not trade_to_edit.empty:
+            trade = trade_to_edit.iloc[0]
+            st.subheader('Edit Trade')
+            with st.form('edit_trade'):
+                date = st.date_input('Date', trade['date'], key='edit_date')
+                ticker = st.text_input('Ticker', trade['ticker'], key='edit_ticker')
+                side = st.selectbox('Side', ['Buy', 'Sell'], index=0 if trade['side'] == 'Buy' else 1, key='edit_side')
+                quantity = st.number_input('Quantity', value=float(trade['quantity']), step=1.0, key='edit_qty')
+                price = st.number_input('Price', value=float(trade['price']), step=0.01, format='%f', key='edit_price')
+                pnl = st.number_input('PnL', value=float(trade['pnl']), step=0.01, format='%f', key='edit_pnl')
+                notes = st.text_area('Notes', trade['notes'], key='edit_notes')
+                tags = st.text_input('Tags (comma separated)', trade['tags'], key='edit_tags')
+                submitted = st.form_submit_button('Update')
+            if submitted:
+                db.update_trade(
+                    trade_id=int(trade['id']),
+                    date=str(date),
+                    ticker=ticker.upper(),
+                    side=side,
+                    quantity=quantity,
+                    price=price,
+                    pnl=pnl,
+                    notes=notes,
+                    tags=tags,
+                )
+                st.success('Trade updated')
+                st.session_state['edit_id'] = None
+                st.experimental_rerun()
+            if st.button('Cancel Edit'):
+                st.session_state['edit_id'] = None
+                st.experimental_rerun()
+
+    # Handle delete confirmation
+    if st.session_state.get('delete_id') is not None:
+        trade_to_delete = trades_df[trades_df['id'] == st.session_state['delete_id']]
+        if not trade_to_delete.empty:
+            trade = trade_to_delete.iloc[0]
+            st.warning(f"Delete trade {trade['ticker']} on {trade['date']}?")
+            col1, col2 = st.columns(2)
+            if col1.button('Confirm Delete'):
+                db.delete_trade(int(trade['id']))
+                st.session_state['delete_id'] = None
+                st.success('Trade deleted')
+                st.experimental_rerun()
+            if col2.button('Cancel'):
+                st.session_state['delete_id'] = None
+                st.experimental_rerun()
 
     st.header('Trades')
-    trades_df = db.fetch_trades()
     if not trades_df.empty:
         trades_df['date'] = pd.to_datetime(trades_df['date']).dt.date
         st.dataframe(trades_df)
+        for _, row in trades_df.iterrows():
+            c1, c2, c3 = st.columns([6, 1, 1])
+            c1.write(
+                f"{row['date']} {row['ticker']} {row['side']} Qty:{row['quantity']} "
+                f"Price:{row['price']} PnL:{row['pnl']}"
+            )
+            if c2.button('Edit', key=f"edit_{row['id']}"):
+                st.session_state['edit_id'] = row['id']
+                st.experimental_rerun()
+            if c3.button('Delete', key=f"delete_{row['id']}"):
+                st.session_state['delete_id'] = row['id']
+                st.experimental_rerun()
         st.download_button('Export CSV', trades_df.to_csv(index=False),
                            'trades.csv')
     else:

--- a/tradeledger/app.py
+++ b/tradeledger/app.py
@@ -2,8 +2,8 @@ import streamlit as st
 import pandas as pd
 from datetime import datetime
 
-from . import db
-from . import utils
+import db
+import utils
 
 # Initialize database
 if 'db_initialized' not in st.session_state:

--- a/tradeledger/app.py
+++ b/tradeledger/app.py
@@ -39,7 +39,7 @@ if page == 'Trade Log':
                 tags=tags,
             )
             st.success('Trade added')
-            st.experimental_rerun()
+            utils.rerun()
 
     trades_df = db.fetch_trades()
 
@@ -73,10 +73,10 @@ if page == 'Trade Log':
                 )
                 st.success('Trade updated')
                 st.session_state['edit_id'] = None
-                st.experimental_rerun()
+                utils.rerun()
             if st.button('Cancel Edit'):
                 st.session_state['edit_id'] = None
-                st.experimental_rerun()
+                utils.rerun()
 
     # Handle delete confirmation
     if st.session_state.get('delete_id') is not None:
@@ -89,10 +89,10 @@ if page == 'Trade Log':
                 db.delete_trade(int(trade['id']))
                 st.session_state['delete_id'] = None
                 st.success('Trade deleted')
-                st.experimental_rerun()
+                utils.rerun()
             if col2.button('Cancel'):
                 st.session_state['delete_id'] = None
-                st.experimental_rerun()
+                utils.rerun()
 
     st.header('Trades')
     if not trades_df.empty:
@@ -106,10 +106,10 @@ if page == 'Trade Log':
             )
             if c2.button('Edit', key=f"edit_{row['id']}"):
                 st.session_state['edit_id'] = row['id']
-                st.experimental_rerun()
+                utils.rerun()
             if c3.button('Delete', key=f"delete_{row['id']}"):
                 st.session_state['delete_id'] = row['id']
-                st.experimental_rerun()
+                utils.rerun()
         st.download_button('Export CSV', trades_df.to_csv(index=False),
                            'trades.csv')
     else:

--- a/tradeledger/app.py
+++ b/tradeledger/app.py
@@ -1,0 +1,71 @@
+import streamlit as st
+import pandas as pd
+from datetime import datetime
+
+from . import db
+from . import utils
+
+# Initialize database
+if 'db_initialized' not in st.session_state:
+    db.init_db()
+    st.session_state['db_initialized'] = True
+
+st.title('TradeLedger')
+
+pages = ['Trade Log', 'Dashboard']
+page = st.sidebar.selectbox('Navigation', pages)
+
+if page == 'Trade Log':
+    st.header('Add Trade')
+    with st.form('add_trade'):
+        date = st.date_input('Date', datetime.now().date())
+        ticker = st.text_input('Ticker')
+        side = st.selectbox('Side', ['Buy', 'Sell'])
+        quantity = st.number_input('Quantity', value=0.0, step=1.0)
+        price = st.number_input('Price', value=0.0, step=0.01, format='%f')
+        pnl = st.number_input('PnL', value=0.0, step=0.01, format='%f')
+        notes = st.text_area('Notes')
+        tags = st.text_input('Tags (comma separated)')
+        submitted = st.form_submit_button('Add')
+        if submitted and ticker:
+            db.add_trade(
+                date=str(date),
+                ticker=ticker.upper(),
+                side=side,
+                quantity=quantity,
+                price=price,
+                pnl=pnl,
+                notes=notes,
+                tags=tags,
+            )
+            st.success('Trade added')
+
+    st.header('Trades')
+    trades_df = db.fetch_trades()
+    if not trades_df.empty:
+        trades_df['date'] = pd.to_datetime(trades_df['date']).dt.date
+        st.dataframe(trades_df)
+        st.download_button('Export CSV', trades_df.to_csv(index=False),
+                           'trades.csv')
+    else:
+        st.info('No trades recorded yet.')
+
+elif page == 'Dashboard':
+    st.header('Performance Dashboard')
+    trades_df = db.fetch_trades()
+    if trades_df.empty:
+        st.info('No trades to display.')
+    else:
+        trades_df['date'] = pd.to_datetime(trades_df['date'])
+        daily = utils.aggregate_pnl(trades_df, 'D')
+        weekly = utils.aggregate_pnl(trades_df, 'W')
+        monthly = utils.aggregate_pnl(trades_df, 'M')
+
+        st.subheader('Daily P&L')
+        st.line_chart(daily.set_index('date'))
+
+        st.subheader('Weekly P&L')
+        st.bar_chart(weekly.set_index('date'))
+
+        st.subheader('Monthly P&L')
+        st.bar_chart(monthly.set_index('date'))

--- a/tradeledger/db.py
+++ b/tradeledger/db.py
@@ -1,0 +1,77 @@
+import sqlite3
+from typing import Optional
+import pandas as pd
+
+DB_NAME = "trades.db"
+
+
+def init_db(db_name: str = DB_NAME) -> None:
+    """Initialize the SQLite database and create the trades table if it doesn't exist."""
+    conn = sqlite3.connect(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS trades (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,
+            ticker TEXT NOT NULL,
+            side TEXT,
+            quantity REAL,
+            price REAL,
+            pnl REAL,
+            notes TEXT,
+            tags TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def get_connection(db_name: str = DB_NAME) -> sqlite3.Connection:
+    return sqlite3.connect(db_name, detect_types=sqlite3.PARSE_DECLTYPES)
+
+
+def add_trade(date: str, ticker: str, side: str, quantity: float, price: float, pnl: float,
+              notes: str = "", tags: str = "", db_name: str = DB_NAME) -> None:
+    conn = get_connection(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT INTO trades (date, ticker, side, quantity, price, pnl, notes, tags)"
+        " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (date, ticker, side, quantity, price, pnl, notes, tags)
+    )
+    conn.commit()
+    conn.close()
+
+
+def update_trade(trade_id: int, date: str, ticker: str, side: str, quantity: float,
+                 price: float, pnl: float, notes: str = "", tags: str = "",
+                 db_name: str = DB_NAME) -> None:
+    conn = get_connection(db_name)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        UPDATE trades SET date=?, ticker=?, side=?, quantity=?, price=?, pnl=?,
+        notes=?, tags=? WHERE id=?
+        """,
+        (date, ticker, side, quantity, price, pnl, notes, tags, trade_id)
+    )
+    conn.commit()
+    conn.close()
+
+
+def delete_trade(trade_id: int, db_name: str = DB_NAME) -> None:
+    conn = get_connection(db_name)
+    cursor = conn.cursor()
+    cursor.execute("DELETE FROM trades WHERE id=?", (trade_id,))
+    conn.commit()
+    conn.close()
+
+
+def fetch_trades(db_name: str = DB_NAME) -> pd.DataFrame:
+    conn = get_connection(db_name)
+    df = pd.read_sql_query("SELECT * FROM trades ORDER BY date DESC", conn,
+                           parse_dates=["date"])
+    conn.close()
+    return df

--- a/tradeledger/db.py
+++ b/tradeledger/db.py
@@ -7,9 +7,9 @@ DB_NAME = "trades.db"
 
 def init_db(db_name: str = DB_NAME) -> None:
     """Initialize the SQLite database and create the trades table if it doesn't exist."""
-    conn = sqlite3.connect(db_name)
-    cursor = conn.cursor()
-    cursor.execute(
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.cursor()
+        cursor.execute(
         """
         CREATE TABLE IF NOT EXISTS trades (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/tradeledger/requirements.txt
+++ b/tradeledger/requirements.txt
@@ -1,0 +1,2 @@
+streamlit
+pandas

--- a/tradeledger/requirements.txt
+++ b/tradeledger/requirements.txt
@@ -1,2 +1,2 @@
-streamlit==1.13.0
-pandas==2.0.1
+streamlit
+pandas

--- a/tradeledger/requirements.txt
+++ b/tradeledger/requirements.txt
@@ -1,2 +1,2 @@
-streamlit
-pandas
+streamlit==1.13.0
+pandas==2.0.1

--- a/tradeledger/utils.py
+++ b/tradeledger/utils.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+
+def aggregate_pnl(df: pd.DataFrame, freq: str = 'D') -> pd.DataFrame:
+    """Aggregate P&L by a pandas offset alias (e.g., 'D', 'W', 'M')."""
+    if df.empty:
+        return pd.DataFrame(columns=['date', 'pnl'])
+    agg = (
+        df.set_index('date')['pnl']
+        .resample(freq)
+        .sum()
+        .reset_index()
+    )
+    return agg

--- a/tradeledger/utils.py
+++ b/tradeledger/utils.py
@@ -1,6 +1,5 @@
 import pandas as pd
 
-
 def aggregate_pnl(df: pd.DataFrame, freq: str = 'D') -> pd.DataFrame:
     """Aggregate P&L by a pandas offset alias (e.g., 'D', 'W', 'M').
     'M' is mapped to 'MS' for compatibility with pandas >=2.0.
@@ -17,3 +16,20 @@ def aggregate_pnl(df: pd.DataFrame, freq: str = 'D') -> pd.DataFrame:
         .reset_index()
     )
     return agg
+
+
+def rerun() -> None:
+    """Compatibility wrapper for Streamlit rerun.
+
+    Uses ``st.experimental_rerun`` when available and falls back to
+    ``st.rerun`` in newer versions of Streamlit. Raises ``RuntimeError``
+    if neither method exists.
+    """
+    import streamlit as st
+
+    if hasattr(st, "experimental_rerun"):
+        st.experimental_rerun()
+    elif hasattr(st, "rerun"):
+        st.rerun()
+    else:
+        raise RuntimeError("Streamlit rerun not supported in this version")

--- a/tradeledger/utils.py
+++ b/tradeledger/utils.py
@@ -2,9 +2,14 @@ import pandas as pd
 
 
 def aggregate_pnl(df: pd.DataFrame, freq: str = 'D') -> pd.DataFrame:
-    """Aggregate P&L by a pandas offset alias (e.g., 'D', 'W', 'M')."""
+    """Aggregate P&L by a pandas offset alias (e.g., 'D', 'W', 'M').
+    'M' is mapped to 'MS' for compatibility with pandas >=2.0.
+    """
     if df.empty:
         return pd.DataFrame(columns=['date', 'pnl'])
+    # Map deprecated 'M' to 'MS' (month start)
+    if freq == 'M':
+        freq = 'MS'
     agg = (
         df.set_index('date')['pnl']
         .resample(freq)


### PR DESCRIPTION
## Summary
- show edit form pre-filled with trade data
- confirm before deleting a trade
- refresh UI after each edit or delete

## Testing
- `python -m py_compile tradeledger/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ff45db78832e983d9632220fa2bb